### PR TITLE
docker: Remove awk symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,8 +74,6 @@ RUN apt-get update \
 
 RUN pip3 install cwlref-runner html5lib
 
-RUN ln -s /usr/bin/gawk /bin/awk
-
 COPY --from=builder /usr/local/bin/bwa /usr/local/bin/bwa
 COPY --from=builder /usr/local/bin/samtools /usr/local/bin/samtools
 COPY --from=builder /usr/local/bin/sambamba /usr/local/bin/sambamba


### PR DESCRIPTION
The invocation of awk used to be hardcoded to `/bin/awk`, but this was
changed to use the environment path in
13e2f1dd5896df73df58a355062101b859916ec8.