### PR TITLE
Use sambamba to extract unmapped reads and then merge back in during …

### DIFF
--- a/cwl/extract.cwl
+++ b/cwl/extract.cwl
@@ -94,7 +94,7 @@ steps:
          type: File
          inputBinding: 
            position: 0
-     arguments: ["-h", "-F", "ref_name =~ /\\*/ and unmapped and mate_is_unmapped", "-f", "bam"]
+     arguments: ["-h", "-F", "ref_name =~ /\\*/", "-f", "bam"]
      outputs:
        unmapped_bam:
          type: File

--- a/cwl/extract.cwl
+++ b/cwl/extract.cwl
@@ -18,6 +18,9 @@ outputs:
     type: File[]
     outputSource: [by_chrom/out_bam, mismatch/out_bam]
     linkMerge: merge_flattened
+  unmapped:
+    type: File
+    outputSource: [extract_unmapped/unmapped_bam] 
 
 steps:
   # Step01: extract chromosome information from input bam
@@ -27,6 +30,7 @@ steps:
     out: [chroms]
     run: get_chroms.cwl  
 
+  # Step02a: extract reads where mate is mapped to a different chromosome
   mismatch: 
     in:
       bam: bam
@@ -77,4 +81,24 @@ steps:
            glob: "$(inputs.chroms).bam"
       baseCommand: [java.sh, org.stjude.compbio.sam.TweakSam]
 
+  # Step02c: extract unmapped read pairs
+  extract_unmapped:
+   in:
+     bam: bam
+   out: [unmapped_bam]
+   run: 
+     class: CommandLineTool
+     stdout: unmapped.bam
+     inputs: 
+       bam: 
+         type: File
+         inputBinding: 
+           position: 0
+     arguments: ["-h", "-F", "ref_name =~ /\\*/ and unmapped and mate_is_unmapped", "-f", "bam"]
+     outputs:
+       unmapped_bam:
+         type: File
+         outputBinding:
+           glob: "*.bam"
+     baseCommand: [sambamba, view]
 

--- a/cwl/xenocp.cwl
+++ b/cwl/xenocp.cwl
@@ -62,7 +62,7 @@ steps:
     run: extract.cwl
     in: 
       bam: bam
-    out: [split_bams]
+    out: [split_bams, unmapped]
   
   # Step02: extract mapped reads and convert to fastq
   mapped-fastq:
@@ -123,7 +123,9 @@ steps:
   finish:
     run: merge_markdup_index.cwl
     in:
-      input_bams: cleanse/cleaned_bam
+      input_bams: 
+        source: [cleanse/cleaned_bam, split/unmapped]
+        linkMerge: merge_flattened
       output_bam:
         source: bam
         valueFrom: ${return self.nameroot + ".xenocp.bam"}


### PR DESCRIPTION
Added a sambamba step to extract the reads that are not mapped to a reference contig/chromosome. Then merge them into the final bam for output. This addresses issue #9 