### PR TITLE
fix: Explicitly sort contamination bams by queryname. 

### DIFF
--- a/src/main/java/org/stjude/compbio/xenocp/CreateContamLists.java
+++ b/src/main/java/org/stjude/compbio/xenocp/CreateContamLists.java
@@ -262,7 +262,7 @@ public class CreateContamLists {
 			"read number in the pair.\n\n" +
 			"CAVEAT: All bams must have the NM tag, containing edit\n" +
 			"distance!\n\n" + 
-			"CAVEAT: All contamination bams must be sorted by queryname");
+			"CAVEAT: All contamination bams must be sorted by queryname\n\n");
 		System.exit(exitcode);
 	}
 

--- a/src/main/java/org/stjude/compbio/xenocp/CreateContamLists.java
+++ b/src/main/java/org/stjude/compbio/xenocp/CreateContamLists.java
@@ -261,7 +261,8 @@ public class CreateContamLists {
 			"suffix of [non-alphanumeric char][12] that indicates\n" +
 			"read number in the pair.\n\n" +
 			"CAVEAT: All bams must have the NM tag, containing edit\n" +
-			"distance!");
+			"distance!\n\n" + 
+			"CAVEAT: All contamination bams must be sorted by queryname");
 		System.exit(exitcode);
 	}
 

--- a/src/main/scripts/bwa_alignse_onlymapped.sh
+++ b/src/main/scripts/bwa_alignse_onlymapped.sh
@@ -35,7 +35,7 @@ echo $cmd \> $sai
 $cmd > $sai
 
 # bwa samse | TweakSam
-cmd="bwa samse $PREFIX $sai $FASTQ | java.sh org.stjude.compbio.sam.TweakSam -V SILENT -G 4 -o $BAM"
+cmd="bwa samse $PREFIX $sai $FASTQ | java.sh org.stjude.compbio.sam.TweakSam -V SILENT -G 4 -O queryname -o $BAM"
 echo "$cmd"
 eval $cmd
 

--- a/src/main/scripts/bwa_mem_onlymapped.sh
+++ b/src/main/scripts/bwa_mem_onlymapped.sh
@@ -27,7 +27,7 @@ if [ "$OUT_DIR" != "" -a ! -e "$OUT_DIR" ]; then mkdir -p $OUT_DIR; fi
 SCRATCH=`mktemp -d` || ( echo "Could not get scratch dir" >&2 ; exit 1 )
 
 # bwa mem
-cmd="bwa mem $PREFIX $FASTQ | java.sh org.stjude.compbio.sam.TweakSam -V SILENT -G 4 -o $BAM"
+cmd="bwa mem $PREFIX $FASTQ | java.sh org.stjude.compbio.sam.TweakSam -V SILENT -G 4 -O queryname -o $BAM"
 
 echo $cmd 
 set -e -x

--- a/src/main/scripts/star_onlymapped.sh
+++ b/src/main/scripts/star_onlymapped.sh
@@ -63,7 +63,7 @@ cmd="STAR --genomeDir ${GENOMEDIR} \
              --outFileNamePrefix ${name}. \
              --twopassMode Basic \
              --limitBAMsortRAM 3000000000 \
-            && java.sh org.stjude.compbio.sam.TweakSam -V SILENT -G 4 -o ${BAM} -i ${name}.Aligned.out.bam"
+            && java.sh org.stjude.compbio.sam.TweakSam -V SILENT -G 4 -O queryname -o ${BAM} -i ${name}.Aligned.out.bam"
 
 echo $cmd
 set -e -x


### PR DESCRIPTION
Add queryname requirement to CreateContamLists help text.