### PR TITLE
Bump action version. Update for master->main.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,31 +9,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Sanitize Repo Name for Tagging
         run: echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]' | (read; echo REPO_LOWER=$REPLY) >> $GITHUB_ENV
       - 
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - 
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - 
         name: Login to Docker Hub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - 
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ secrets.GH_USERNAME }}
           password: ${{ secrets.GH_TOKEN }}
       - name: Build and Push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           tags: |

--- a/.github/workflows/docker_branches.yml
+++ b/.github/workflows/docker_branches.yml
@@ -2,7 +2,7 @@ name: Publish Docker image
 on:
   push:
     branches-ignore:
-    - 'master'
+    - 'main'
 
 jobs:
   push_to_registry:
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Sanitize Repo Name for Tagging
         run: echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]' | (read; echo REPO_LOWER=$REPLY) >> $GITHUB_ENV
@@ -25,18 +25,18 @@ jobs:
             type=ref,event=pr
       - 
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - 
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - 
         name: Login to Docker Hub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push to Docker Hub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -19,7 +19,7 @@ jobs:
         for file in $(find . -name '*.wdl'); do
           >&2 echo "Checking file $file..."
           import_lines=$(awk '/import/' "$file")
-          bad_lines=$(echo "$import_lines" | awk '!/https:\/\/raw.githubusercontent.com\/stjude\/xenocp\/main/ && !/https:\/\/raw.githubusercontent.com\/stjudecloud\/workflows\/master/' | grep -v '# lint-check: ignore') || true
+          bad_lines=$(echo "$import_lines" | awk '!/https:\/\/raw.githubusercontent.com\/stjude\/xenocp\/main/ && !/https:\/\/raw.githubusercontent.com\/stjudecloud\/workflows\/main/' | grep -v '# lint-check: ignore') || true
           if [ -n "$bad_lines" ]; then
             >&2 echo "Must import files from the main branch on Github."
             >&2 echo "The following lines are bad:"

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -19,13 +19,24 @@ jobs:
         for file in $(find . -name '*.wdl'); do
           >&2 echo "Checking file $file..."
           import_lines=$(awk '/import/' "$file")
-          bad_lines=$(echo "$import_lines" | awk '!/https:\/\/raw.githubusercontent.com\/stjude\/xenocp\/main/ && !/https:\/\/raw.githubusercontent.com\/stjudecloud\/workflows\/main/' | grep -v '# lint-check: ignore') || true
+
+          bad_lines=$(echo "$import_lines" | awk '/https:\/\/raw.githubusercontent.com\/stjude\/XenoCP/') || true
           if [ -n "$bad_lines" ]; then
-            >&2 echo "Must import files from the main branch on Github."
+            >&2 echo "Imports from this repo must use relative paths!"
             >&2 echo "The following lines are bad:"
             >&2 echo "$bad_lines"
             >&2 echo ""
             EXITCODE=1
           fi
+
+          bad_lines=$(echo "$import_lines" | awk '/http/ && (/main/ || /master/)') || true
+          if [ -n "$bad_lines" ]; then
+            >&2 echo "Imports from external repos must use a tagged release!"
+            >&2 echo "The following lines are bad:"
+            >&2 echo "$bad_lines"
+            >&2 echo ""
+            EXITCODE=1
+          fi
+
         done
         exit $EXITCODE

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -3,25 +3,25 @@ name: lint-check
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   import_syntax_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check import syntax
       run: |
         EXITCODE=0
         for file in $(find . -name '*.wdl'); do
           >&2 echo "Checking file $file..."
           import_lines=$(awk '/import/' "$file")
-          bad_lines=$(echo "$import_lines" | awk '!/https:\/\/raw.githubusercontent.com\/stjude\/xenocp\/master/ && !/https:\/\/raw.githubusercontent.com\/stjudecloud\/workflows\/master/' | grep -v '# lint-check: ignore') || true
+          bad_lines=$(echo "$import_lines" | awk '!/https:\/\/raw.githubusercontent.com\/stjude\/xenocp\/main/ && !/https:\/\/raw.githubusercontent.com\/stjudecloud\/workflows\/master/' | grep -v '# lint-check: ignore') || true
           if [ -n "$bad_lines" ]; then
-            >&2 echo "Must import files from the master branch on Github."
+            >&2 echo "Must import files from the main branch on Github."
             >&2 echo "The following lines are bad:"
             >&2 echo "$bad_lines"
             >&2 echo ""

--- a/.github/workflows/miniwdl-check.yml
+++ b/.github/workflows/miniwdl-check.yml
@@ -6,11 +6,11 @@ jobs:
   miniwdl_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.6'
+        python-version: '3.10'
     - name: Install miniwdl
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/miniwdl-check.yml
+++ b/.github/workflows/miniwdl-check.yml
@@ -22,7 +22,7 @@ jobs:
         files=$(find . -name '*.wdl')
         for file in $files; do
           sed -i 's,https://raw.githubusercontent.com/stjude/xenocp/'"$(echo ${GITHUB_REF#refs/heads/})"','"$(pwd)"',g' "$file"
-          sed -i 's,https://raw.githubusercontent.com/stjude/xenocp/master,'"$(pwd)"',g' "$file"
+          sed -i 's,https://raw.githubusercontent.com/stjude/xenocp/main,'"$(pwd)"',g' "$file"
         done
         for file in $files; do
           echo "  [***] $file [***]"

--- a/.github/workflows/miniwdl-check.yml
+++ b/.github/workflows/miniwdl-check.yml
@@ -20,10 +20,7 @@ jobs:
         EXITCODE=0
         echo "Checking WDL files using \`miniwdl check\`."
         files=$(find . -name '*.wdl')
-        for file in $files; do
-          sed -i 's,https://raw.githubusercontent.com/stjude/xenocp/'"$(echo ${GITHUB_REF#refs/heads/})"','"$(pwd)"',g' "$file"
-          sed -i 's,https://raw.githubusercontent.com/stjude/xenocp/main,'"$(pwd)"',g' "$file"
-        done
+
         for file in $files; do
           echo "  [***] $file [***]"
           miniwdl check "$file"

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -12,7 +12,7 @@ jobs:
   docker_pull_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Ensure SemVer'd docker images are being pulled
       run: |
         EXITCODE=0

--- a/wdl/workflows/xenocp.wdl
+++ b/wdl/workflows/xenocp.wdl
@@ -28,9 +28,9 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/stjude/xenocp/main/wdl/tools/xenocp.wdl" as xenocp_tools
-import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/bwa.wdl"
-import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/star.wdl"
-import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/picard.wdl"
+import "https://raw.githubusercontent.com/stjudecloud/workflows/main/tools/bwa.wdl"
+import "https://raw.githubusercontent.com/stjudecloud/workflows/main/tools/star.wdl"
+import "https://raw.githubusercontent.com/stjudecloud/workflows/main/tools/picard.wdl"
 
 workflow xenocp {
     input {

--- a/wdl/workflows/xenocp.wdl
+++ b/wdl/workflows/xenocp.wdl
@@ -27,10 +27,10 @@
 
 version 1.0
 
-import "https://raw.githubusercontent.com/stjude/xenocp/main/wdl/tools/xenocp.wdl" as xenocp_tools
-import "https://raw.githubusercontent.com/stjudecloud/workflows/main/tools/bwa.wdl"
-import "https://raw.githubusercontent.com/stjudecloud/workflows/main/tools/star.wdl"
-import "https://raw.githubusercontent.com/stjudecloud/workflows/main/tools/picard.wdl"
+import "../tools/xenocp.wdl" as xenocp_tools
+import "https://raw.githubusercontent.com/stjudecloud/workflows/rnaseq-standard/v3.0.0/tools/bwa.wdl"
+import "https://raw.githubusercontent.com/stjudecloud/workflows/rnaseq-standard/v3.0.0/tools/star.wdl"
+import "https://raw.githubusercontent.com/stjudecloud/workflows/rnaseq-standard/v3.0.0/tools/picard.wdl"
 
 workflow xenocp {
     input {

--- a/wdl/workflows/xenocp.wdl
+++ b/wdl/workflows/xenocp.wdl
@@ -27,7 +27,7 @@
 
 version 1.0
 
-import "https://raw.githubusercontent.com/stjude/xenocp/master/wdl/tools/xenocp.wdl" as xenocp_tools
+import "https://raw.githubusercontent.com/stjude/xenocp/main/wdl/tools/xenocp.wdl" as xenocp_tools
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/bwa.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/star.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/picard.wdl"


### PR DESCRIPTION
Updates branch names from "master" to "main" in actions.
Update GitHub action versions to the latest releases.
Update Python version for miniwdl check.

Switch internal WDL imports to use relative paths. Now both `miniwdl` and `cromwell` support relative paths for all types of specifications. This will simplify things as now the import will use the corresponding tool file to whatever workflow is run.

Switch to using tagged imports from external repositories. This will prevent pulling potentially breaking changes unintentionally.
