### PR TITLE
Point to updated STAR release

### DIFF
--- a/wdl/workflows/xenocp.wdl
+++ b/wdl/workflows/xenocp.wdl
@@ -28,9 +28,9 @@
 version 1.0
 
 import "../tools/xenocp.wdl" as xenocp_tools
-import "https://raw.githubusercontent.com/stjudecloud/workflows/rnaseq-standard/v3.0.0/tools/bwa.wdl"
-import "https://raw.githubusercontent.com/stjudecloud/workflows/rnaseq-standard/v3.0.0/tools/star.wdl"
-import "https://raw.githubusercontent.com/stjudecloud/workflows/rnaseq-standard/v3.0.0/tools/picard.wdl"
+import "https://raw.githubusercontent.com/stjudecloud/workflows/rnaseq-standard/v4.0.0-alpha/tools/bwa.wdl"
+import "https://raw.githubusercontent.com/stjudecloud/workflows/rnaseq-standard/v4.0.0-alpha/tools/star.wdl"
+import "https://raw.githubusercontent.com/stjudecloud/workflows/rnaseq-standard/v4.0.0-alpha/tools/picard.wdl"
 
 workflow xenocp {
     input {


### PR DESCRIPTION
In sync with changes to the St. Jude Cloud workflows repository (https://github.com/stjudecloud/workflows), updating tool paths to pull new Docker images, which includes an updated version of STAR.