### PR TITLE
Rewrite BAM header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,21 +15,22 @@ RUN apt-get update \
 
 RUN pip3 install --user --ignore-installed \
         cwlref-runner \
-        html5lib
+        html5lib \
+        urllib3==1.26.15
 
 RUN cd /tmp \
-    && wget https://github.com/lh3/bwa/releases/download/v0.7.13/bwa-0.7.13.tar.bz2 \
-    && echo "559b3c63266e5d5351f7665268263dbb9592f3c1c4569e7a4a75a15f17f0aedc *bwa-0.7.13.tar.bz2" | sha256sum --check \
-    && tar xf bwa-0.7.13.tar.bz2 \
-    && cd bwa-0.7.13 \
+    && wget https://github.com/lh3/bwa/releases/download/v0.7.17/bwa-0.7.17.tar.bz2 \
+    && echo "de1b4d4e745c0b7fc3e107b5155a51ac063011d33a5d82696331ecf4bed8d0fd *bwa-0.7.17.tar.bz2" | sha256sum --check \
+    && tar xf bwa-0.7.17.tar.bz2 \
+    && cd bwa-0.7.17 \
     && make -j$(nproc) \
     && mv bwa /usr/local/bin
 
 RUN cd /tmp \
-    && wget https://github.com/alexdobin/STAR/archive/2.7.1a.tar.gz \
-    && echo "9a35bf4e8a12bec505e11132bc53f94671f596584a6a0dd8f237120dd0df740e *2.7.1a.tar.gz" | sha256sum --check \
-    && tar xf 2.7.1a.tar.gz \
-    && mv STAR-2.7.1a/bin/Linux_x86_64_static/STAR /usr/local/bin
+    && wget https://github.com/alexdobin/STAR/archive/refs/tags/2.7.10a.tar.gz \
+    && echo "af0df8fdc0e7a539b3ec6665dce9ac55c33598dfbc74d24df9dae7a309b0426a *2.7.10a.tar.gz" | sha256sum --check \
+    && tar xf 2.7.10a.tar.gz \
+    && mv STAR-2.7.10a/bin/Linux_x86_64_static/STAR /usr/local/bin
 
 # bz2 and lzma support is for CRAM files. curses is for `samtools tview`.
 RUN cd /tmp \

--- a/bin/finalize_bam.sh
+++ b/bin/finalize_bam.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Clean duplicate BAM header records from STAR aligned BAMs
+# Add @PG record for XenoCP
+#
+# $1 = input bam
+# $2 = output bam
+# $3 = reference database
+# $4 = aligner [star, bwa mem, bwa aln] used to search host genome
+# $5 = original input BAM
+
+# Show usage information if no parameters were sent
+if [ "$#" == 0 ]; then about.sh $0; exit 1; fi
+
+BAM=$1
+OUTPUT=$2
+
+REFERENCE=$3
+ALIGNER=$4
+INPUT_BAM=$5
+
+# Get BAM header and remove any consecutive duplicate records
+# STAR aligned BAMs have a @CO record that gets duplicated 
+# during XenoCP
+samtools view -H ${BAM} | uniq > header.txt
+
+# Get the ID value from the last @PG record
+PG=$(awk '/^@PG/ {l=$0} END{match(l, /.*ID:([^\t]+).*/, arr); print arr[1] }' header.txt)
+
+# Add a XenoCP @PG record to the BAM header
+echo -e "@PG\tID:XenoCP\tPN:XenoCP\tCL:INPUT_BAM=${INPUT_BAM} \
+ALIGNER=${ALIGNER} REFERENCE=${REFERENCE}\tDS:Unmap reads that \
+are identified as deriving from the contaminant (host) genome \
+\tPP:${PG}\tVN:4.0.0-alpha" >> header.txt
+
+# Write the new header to an output BAM
+samtools reheader header.txt ${BAM} > ${OUTPUT}
+
+samtools index ${OUTPUT} ${OUTPUT}.bai
+
+# Compute MD5 sum
+if which md5sum > /dev/null
+then
+  md5sum ${OUTPUT} > ${OUTPUT}.md5
+elif which md5 > /dev/null
+then
+  md5 -q ${OUTPUT} > ${OUTPUT}.md5
+else
+  echo "No MD5 program found" >&2; exit 1
+fi

--- a/cwl/finalize_bam.cwl
+++ b/cwl/finalize_bam.cwl
@@ -1,0 +1,58 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.2
+class: CommandLineTool
+doc: |
+  Clean duplicate BAM header records from STAR aligned BAMs.
+  Add @PG record for XenoCP Also calculates flagstat
+  and md5. 
+
+requirements:
+ - class: InlineJavascriptRequirement
+
+hints:
+  SoftwareRequirement:
+    packages:
+      finalize_bam:
+        specs: ["finalize_bam.sh"]
+
+baseCommand: finalize_bam.sh
+
+inputs:
+  input_bam:
+    type: File
+    inputBinding:
+      position: 1
+    doc: |
+      BAM file to clean. 
+  output_bam:
+    type: string
+    inputBinding:
+      position: 2
+    doc: |
+      Name of final output bam file.
+      Must have '.bam' extension. 
+  ref_db_prefix: 
+    type: string
+    inputBinding:
+      position: 3
+  aligner:
+    type:
+      type: enum
+      symbols: ["bwa aln", "bwa mem", "star"]
+      name: aligner
+    inputBinding:
+      position: 4
+  original_bam_name:
+    type: string
+    inputBinding:
+      position: 5
+
+outputs:
+  final_bam:
+    type: File
+    secondaryFiles: 
+      - .md5
+      - .bai
+    outputBinding:
+      glob: $(inputs.output_bam)

--- a/cwl/xenocp.cwl
+++ b/cwl/xenocp.cwl
@@ -46,7 +46,7 @@ inputs:
 outputs:
   output_bam:
     type: File
-    outputSource: finish/final_bam
+    outputSource: clean_bam_header/final_bam
   flagstat:
     type: File
     outputSource: finish/flagstat
@@ -181,7 +181,7 @@ steps:
         linkMerge: merge_flattened
       output_bam:
         source: bam
-        valueFrom: ${return self.nameroot + ".xenocp.bam"}
+        valueFrom: ${return self.nameroot + ".tmp.bam"}
       n_threads: n_threads
     out: [final_bam, flagstat]
 
@@ -210,11 +210,27 @@ steps:
         valueFrom: ${return self.nameroot + ".contam.txt"}
     out: [combined_file]
 
-  # Step08: QC the merged bam
+  # Step08: Clean BAM header
+  clean_bam_header:
+    run: finalize_bam.cwl
+    in:
+      input_bam:
+        source: finish/final_bam
+      output_bam:
+        source: bam
+        valueFrom: ${return self.nameroot + ".xenocp.bam"}
+      ref_db_prefix: ref_db_prefix
+      aligner: aligner
+      original_bam_name:
+        source: bam
+        valueFrom: ${return self.basename}
+    out: [final_bam]
+
+  # Step09: QC the merged bam
   finalqc:
     run: qc_bam.cwl
     in:
-      bam: finish/final_bam
+      bam: clean_bam_header/final_bam
       flagstat: finish/flagstat
     out: []
 


### PR DESCRIPTION
Rewrite the BAM header to remove duplicate @CO records that result from splitting and merging the BAM file. Also, add a @PG record to record the XenoCP run.

Also updates the version of STAR and BWA to match what is being used in the St. Jude Cloud workflows repository. Without this change, the CWL and WDL workflows would use different aligner versions.