### PR TITLE
fix: remove root dependency

### DIFF
--- a/.github/workflows/docker_branches.yml
+++ b/.github/workflows/docker_branches.yml
@@ -19,7 +19,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images:  ${{ env.REPO_LOWER }}
+          images: |
+            ${{ env.REPO_LOWER }}
+            ghcr.io/${{ env.REPO_LOWER }}
           tags: |
             type=ref,event=branch,prefix=branch-
             type=ref,event=pr
@@ -35,8 +37,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_TOKEN }}
       - name: Push to Docker Hub
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update \
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --user --ignore-installed \
+RUN pip3 install --ignore-installed \
+        --prefix /usr/local \
         cwlref-runner \
         html5lib
 
@@ -88,17 +89,16 @@ RUN apt-get update \
         file \
     && rm -rf /var/lib/apt/lists/*
 
-ENV PATH /root/.local/bin:$PATH
+COPY --chmod=755 --from=builder /usr/local/bin/cwl* /usr/local/bin/
+COPY --chmod=755 --from=builder /usr/local/lib /usr/local/lib/
+COPY --chmod=755 --from=builder /usr/local/bin/bwa /usr/local/bin/bwa
+COPY --chmod=755 --from=builder /usr/local/bin/STAR /usr/local/bin/STAR
+COPY --chmod=755 --from=builder /usr/local/bin/samtools /usr/local/bin/samtools
+COPY --chmod=755 --from=builder /usr/local/bin/sambamba /usr/local/bin/sambamba
+COPY --chmod=755 --from=builder /opt/picard /opt/picard
+COPY --chmod=755 --from=builder /opt/xenocp /opt/xenocp
+COPY --chmod=755 --from=builder /opt/xenocp/bin/* /usr/local/bin/
 
-COPY --from=builder /root/.local /root/.local
-COPY --from=builder /usr/local/bin/bwa /usr/local/bin/bwa
-COPY --from=builder /usr/local/bin/STAR /usr/local/bin/STAR
-COPY --from=builder /usr/local/bin/samtools /usr/local/bin/samtools
-COPY --from=builder /usr/local/bin/sambamba /usr/local/bin/sambamba
-COPY --from=builder /opt/picard /opt/picard
-COPY --from=builder /opt/xenocp /opt/xenocp
-COPY --from=builder /opt/xenocp/bin/* /usr/local/bin/
-
-COPY cwl /opt/xenocp/cwl
+COPY --chmod=755  cwl /opt/xenocp/cwl
 
 ENTRYPOINT ["cwl-runner", "--parallel", "--outdir", "results", "--no-container", "/opt/xenocp/cwl/xenocp.cwl"]


### PR DESCRIPTION
Install CWL tools in `/usr/local` rather than under `/root`. Update copies to ensure that they are globally readable. This should enable `singularity` use cases for XenoCP.