### PR TITLE
Explicitly declare insert columns

### DIFF
--- a/src/main/scripts/add_bam_pair_xenocp.py
+++ b/src/main/scripts/add_bam_pair_xenocp.py
@@ -102,7 +102,7 @@ def add_bam_pair_stp(raptr, sample, target, project, subproject, **kwargs):
     bam_tpl_id_xenocp = raptr.fetch_item_or_fail(query, (stp_id,))
 
     # Associate loadables with new bam_tpl.
-    query = """insert into bam_tpl_read_group values (%s, %s)"""
+    query = """insert into bam_tpl_read_group(bam_tpl_id, read_group_id) values (%s, %s)"""
     for rgid in rg_ids:
         raptr.execute(query, (bam_tpl_id_xenocp, rgid))
 


### PR DESCRIPTION
To create `raptr.bam_tpl_read_group` I renamed `raptr.bam_tpl_loadable`, added the `read_group_id` column, backfilled it, and dropped the `loadable_id` column. Previously, `bam_tpl_id` and `loadable_id` were the first two columns, so when `add_bam_pair_xenocp.py` tried to insert using insert into `raptr.bam_tpl_loadable values (%s, %s)` without explicitly stating the columns being inserted, everything was fine, but now that the columns have moved around, postgres thinks it's trying to insert values for `bam_tpl_id` and `inserted_time` because those are the first two columns.

This PR updates the insert statement to explicitly declare the columns being inserted.