### PR TITLE
Remove extra quotes and name derived table

### DIFF
--- a/src/main/scripts/add_bam_pair_xenocp.py
+++ b/src/main/scripts/add_bam_pair_xenocp.py
@@ -164,7 +164,7 @@ def add_bam_pair_bam_id(raptr, bam_id, **kwargs):
     """
     query = """select formal_name, target_name, project_name, subproject from sample_target_project_view inner join
             (select sample_target_project_id from bam_and_tpl where bam_id = %s and bam_status = 'Normal'
-            and legacy = false)
+            and legacy = false) bt
             using (sample_target_project_id);"""
     (sample, target, project, subproject) = raptr.fetch_row_or_fail(query, (bam_id,))
     add_bam_pair_stp(raptr, sample, target, project, subproject)

--- a/src/main/scripts/add_bam_pair_xenocp.py
+++ b/src/main/scripts/add_bam_pair_xenocp.py
@@ -111,7 +111,7 @@ def add_bam_pair_stp(raptr, sample, target, project, subproject, **kwargs):
     genome_id = raptr.fetch_item_or_fail(query, (bam_id,))
 
     # Get anls type named xenocp
-    query = """select anls_type_id from raptr.anls_type where name='%s'"""
+    query = """select anls_type_id from raptr.anls_type where name=%s"""
     anls_type_id = raptr.fetch_item_or_fail(query, ('xenocp',))
 
     # Add a new bam


### PR DESCRIPTION
This PR removes a set of erroneous single quotes in the new select statement that gets the anls_type_id for xenocp. It also adds a name to a derived table further down the same script.